### PR TITLE
Dbacld 187307 - Extend web.xml customization to allow editing <init-param> in filter section

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.git/.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-10T14:44:04Z",
+  "generated_at": "2025-08-26T13:49:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -705,16 +705,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 16,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh": [
-      {
-        "hashed_secret": "d6d3805d3ad80dec2b2864b86d74ca38951271f9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 160,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -288,7 +288,7 @@ function applyWebXmlChangesFromFile() {
       [[ -z "$scope" ]] && scope="context-param"   # default if missing
       updateContextInitParamInWebXml remove "$paramName" "" "$scope"
 
-    # Add/Remove case: paramName=paramValue
+    # Add/Update case: paramName=paramValue
     elif [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
       [[ -z "$scope" ]] && scope="context-param"   # default if missing
       if [[ "$scope" == "context-param" || "$scope" == "init-param" ]]; then
@@ -303,8 +303,10 @@ function applyWebXmlChangesFromFile() {
           paramValue="${paramValue//&/&amp;}"
           paramValue="${paramValue//</&lt;}"
           paramValue="${paramValue//>/&gt;}"
+          updateContextInitParamInWebXml update "$paramName" "$paramValue" "$scope"
+        else
+          echo "The param value of $paramName is null. No action taken. Check your configuration file."
         fi
-        updateContextInitParamInWebXml update "$paramName" "$paramValue" "$scope"
       else
         echo "No action as the scope: $scope should be either context-param or init-param. Check your configuration file."
       fi

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -304,7 +304,9 @@ function applyWebXmlChangesFromFile() {
         paramValue="${paramValue//\\#/\\#}"  # allow escaped "#"
         # Escape special characters & < > " ' in parameter value
         if [[ -n "$paramValue" ]]; then
-            paramValue=$(echo "$paramValue" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g;')
+          paramValue="${paramValue//&/&amp;}"
+          paramValue="${paramValue//</&lt;}"
+          paramValue="${paramValue//>/&gt;}"
         fi
         updateContextInitParamInWebXml update "$paramName" "$paramValue" "$scope"
       else

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -176,11 +176,11 @@ function updateContextInitParamInWebXml() {
       if [[ "$scope" == "context-param" ]]; then
         searchContextParam=$(xmllint --xpath "boolean(//*[local-name()='web-app']/*[local-name()='context-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
         if [[ $searchContextParam == "true" ]]; then
-          currentContextParamValue=$(xmllint --xpath "string(//*[local-name()='context-param'][*[local-name()='param-name' and text()='$paramName']]/*[local-name()='param-value'])" $webXml 2>/dev/null)
+          currentContextParamValue=$(xmllint --xpath "string(//*[local-name()='context-param'][*[local-name()='param-name' and text()='$paramName']]/*[local-name()='param-value'])" "$webXml" 2>/dev/null)
           if [[ "$currentContextParamValue" == "$paramValue" ]]; then
             echo "$scope '$paramName' already has value '$paramValue'. No update needed."
           else          
-            result="$(xmllint --shell $webXml 2>&1 >/dev/null << EOF 
+            result="$(xmllint --shell "$webXml" 2>&1 >/dev/null << EOF 
 setns x=https://jakarta.ee/xml/ns/jakartaee
 cd x:web-app/x:context-param[x:param-name='$paramName']/x:param-value
 set $paramValue
@@ -200,7 +200,7 @@ EOF
 \t\t<param-name>'$paramName'</param-name>\
 \t\t<param-value>'$paramValue'</param-value>\
 \t</context-param>
-' $webXml
+' "$webXml"
         fi
       elif [ "$scope" = "init-param" ]; then
         searchInitParam=$(xmllint --xpath "boolean(//*[local-name()='filter']/*[local-name()='init-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
@@ -239,11 +239,7 @@ EOF
         searchContextParam=$(xmllint --xpath "boolean(//*[local-name()='web-app']/*[local-name()='context-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
         if [[ $searchContextParam == "true" ]]; then
           echo "Removing $scope: $paramName"
-          sed -i "/<context-param>/{:a;N;/<\/context-param>/!ba;/<param-name>$paramName<\/param-name>/d}" $webXml
-          
-          #xmlstarlet ed -P -L \
-          #  -N x="https://jakarta.ee/xml/ns/jakartaee" \
-          #  -d "//x:web-app/x:context-param[x:param-name='$paramName']" $webXml
+          sed -i "/<context-param>/{:a;N;/<\/context-param>/!ba;/<param-name>$paramName<\/param-name>/d}" "$webXml"
         else
           echo "'$paramName' not found in $scope. No removal needed."
         fi
@@ -251,10 +247,7 @@ EOF
         searchInitParam=$(xmllint --xpath "boolean(//*[local-name()='filter']/*[local-name()='init-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
         if [[ $searchInitParam == "true" ]]; then
           echo "Removing $scope: $paramName"
-          sed -i "/<init-param>/{:a;N;/<\/init-param>/!ba;/<param-name>$paramName<\/param-name>/d}" $webXml
-          #xmlstarlet ed -P -L \
-          #  -N x="https://jakarta.ee/xml/ns/jakartaee" \
-          #  -d "//x:web-app/x:filter/x:init-param[x:param-name='$paramName']" $webXml
+          sed -i "/<init-param>/{:a;N;/<\/init-param>/!ba;/<param-name>$paramName<\/param-name>/d}" "$webXml"
         else
           echo "'$paramName' not found in $scope. No removal needed."
         fi
@@ -301,9 +294,12 @@ function applyWebXmlChangesFromFile() {
       if [[ "$scope" == "context-param" || "$scope" == "init-param" ]]; then
         paramName="${BASH_REMATCH[1]}"
         paramValue="${BASH_REMATCH[2]}"
-        paramValue="${paramValue//\\#/\\#}"  # allow escaped "#"
-        # Escape special characters & < > " ' in parameter value
+
         if [[ -n "$paramValue" ]]; then
+          # Allow escaped "#"
+          paramValue="${paramValue//\\#/\\#}"  
+
+          # Escape special characters & < > in parameter value
           paramValue="${paramValue//&/&amp;}"
           paramValue="${paramValue//</&lt;}"
           paramValue="${paramValue//>/&gt;}"

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -164,7 +164,7 @@ else
         sed -i 's|RELEASE_NAME|'$HOSTNAME'|g' /config/httpSession.xml
 fi
 
-function updateContextParamPropertyInWebXml() {
+function updateContextInitParamInWebXml() {
   action="$1"        # update | remove
   paramName="$2"     # <param-name>
   paramValue="$3"    # <param-value>, required for update
@@ -263,7 +263,7 @@ EOF
       
     *)
       echo "Invalid action: $action"
-      echo "Usage: updateContextParamPropertyInWebXml <update|remove> <paramName> [paramValue] <context-param|init-param>"
+      echo "Usage: updateContextInitParamInWebXml <update|remove> <paramName> [paramValue] <context-param|init-param>"
       return 1
       ;;
   esac
@@ -289,10 +289,11 @@ function applyWebXmlChangesFromFile() {
       continue
     fi
 
-    # Remove case: -paramName
-    if [[ "$line" =~ ^-(.+)$ ]]; then
+    # Remove case: -paramName or -paramName=paramValue
+    if [[ "$line" =~ ^-([[:alnum:]._-]+)([=].*)? ]]; then
+      paramName="${BASH_REMATCH[1]}"
       [[ -z "$scope" ]] && scope="context-param"   # default if missing
-      updateContextParamPropertyInWebXml remove "${BASH_REMATCH[1]}" "" "$scope"
+      updateContextInitParamInWebXml remove "$paramName" "" "$scope"
 
     # Add/Remove case: paramName=paramValue
     elif [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
@@ -305,7 +306,7 @@ function applyWebXmlChangesFromFile() {
         if [[ -n "$paramValue" ]]; then
             paramValue=$(echo "$paramValue" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g;')
         fi
-        updateContextParamPropertyInWebXml update "$paramName" "$paramValue" "$scope"
+        updateContextInitParamInWebXml update "$paramName" "$paramValue" "$scope"
       else
         echo "No action as the scope: $scope should be either context-param or init-param. Check your configuration file."
       fi

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -217,7 +217,7 @@ save
 EOF
 )"
           	if [[ "$result" != *"error"* ]]; then
-		          echo "Updated $scope '$paramName' from '$currentContextParamValue' to '$paramValue' in the web.xml file"
+		          echo "Updated $scope '$paramName' from '$currentInitParamValue' to '$paramValue' in the web.xml file"
 	          else
 		          echo "Unable to set property '$paramName' in the web.xml file"
 	          fi

--- a/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
+++ b/decisionserver/decisionserverruntime/script/updateDSRConfigurations.sh
@@ -165,39 +165,161 @@ else
 fi
 
 function updateContextParamPropertyInWebXml() {
-  if grep -q "<param-name>$1</param-name>" $APPS/DecisionService.war/WEB-INF/web.xml; then
-    echo "Setting parameter $1 to $2 in the web.xml file"
-	  result="$(xmllint --shell $APPS/DecisionService.war/WEB-INF/web.xml 2>&1 >/dev/null << EOF
+  action="$1"        # update | remove
+  paramName="$2"     # <param-name>
+  paramValue="$3"    # <param-value>, required for update
+  scope="$4"         # context-param | init-param
+  webXml= "$APPS/DecisionService.war/WEB-INF/web.xml" # web.xml to be updated
+
+  case "$action" in
+    update)
+      if [[ "$scope" == "context-param" ]]; then
+        searchContextParam=$(xmllint --xpath "boolean(//*[local-name()='web-app']/*[local-name()='context-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
+        if [[ $searchContextParam == "true" ]]; then
+          currentContextParamValue=$(xmllint --xpath "string(//*[local-name()='context-param'][*[local-name()='param-name' and text()='$paramName']]/*[local-name()='param-value'])" $webXml 2>/dev/null)
+          if [[ "$currentContextParamValue" == "$paramValue" ]]; then
+            echo "$scope '$paramName' already has value '$paramValue'. No update needed."
+          else          
+            result="$(xmllint --shell $webXml 2>&1 >/dev/null << EOF 
 setns x=https://jakarta.ee/xml/ns/jakartaee
-cd x:web-app/x:context-param[x:param-name='$1']/x:param-value
-set $2
+cd x:web-app/x:context-param[x:param-name='$paramName']/x:param-value
+set $paramValue
 save
 EOF
 )"
-	else
-    echo "Adding context-param $1 with value $2 in the web.xml file"
-    sed -i '/<\/web-app>/i\
-	<context-param>\
-		<param-name>'$1'</param-name>\
-		<param-value>'$2'</param-value>\
-	</context-param>
-    ' $APPS/DecisionService.war/WEB-INF/web.xml
+          	if [[ "$result" != *"error"* ]]; then
+		          echo "Updated $scope '$paramName' from '$currentContextParamValue' to '$paramValue' in the web.xml file"
+	          else
+		          echo "Unable to set property '$paramName' in the web.xml file"
+	          fi
+          fi
+        else
+          echo "Adding $scope '$paramName' with value '$paramValue'"
+          sed -i '/<\/web-app>/i\
+\t<context-param>\
+\t\t<param-name>'$paramName'</param-name>\
+\t\t<param-value>'$paramValue'</param-value>\
+\t</context-param>
+' $webXml
+        fi
+      elif [ "$scope" = "init-param" ]; then
+        searchInitParam=$(xmllint --xpath "boolean(//*[local-name()='filter']/*[local-name()='init-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
+        if [[ $searchInitParam == "true" ]]; then        
+          currentInitParamValue=$(xmllint --xpath "string(//*[local-name()='filter']//*[local-name()='init-param'][*[local-name()='param-name' and text()='$paramName']]/*[local-name()='param-value'])" "$webXml" 2>/dev/null)
+          if [[ "$currentInitParamValue" == "$paramValue" ]]; then
+            echo "$scope '$paramName' already has value '$paramValue'. No update needed."
+          else
+            result="$(xmllint --shell "$webXml" 2>&1 >/dev/null<< EOF
+setns x=https://jakarta.ee/xml/ns/jakartaee
+cd x:web-app/x:filter/x:init-param[x:param-name='$paramName']/x:param-value
+set $paramValue
+save
+EOF
+)"
+          	if [[ "$result" != *"error"* ]]; then
+		          echo "Updated $scope '$paramName' from '$currentContextParamValue' to '$paramValue' in the web.xml file"
+	          else
+		          echo "Unable to set property '$paramName' in the web.xml file"
+	          fi
+          fi
+        else
+          echo "Adding $scope '$paramName' with value '$paramValue'"
+          sed -i '/<\/filter>/i\
+\t\t<init-param>\
+\t\t\t<param-name>'$paramName'</param-name>\
+\t\t\t<param-value>'$paramValue'</param-value>\
+\t\t</init-param>
+' "$webXml"
+        fi
+      fi
+      ;;
 
-	fi
+    remove)
+      if [ "$scope" = "context-param" ]; then
+        searchContextParam=$(xmllint --xpath "boolean(//*[local-name()='web-app']/*[local-name()='context-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
+        if [[ $searchContextParam == "true" ]]; then
+          echo "Removing $scope: $paramName"
+          sed -i "/<context-param>/{:a;N;/<\/context-param>/!ba;/<param-name>$paramName<\/param-name>/d}" $webXml
+          
+          #xmlstarlet ed -P -L \
+          #  -N x="https://jakarta.ee/xml/ns/jakartaee" \
+          #  -d "//x:web-app/x:context-param[x:param-name='$paramName']" $webXml
+        else
+          echo "'$paramName' not found in $scope. No removal needed."
+        fi
+      elif [ "$scope" = "init-param" ]; then
+        searchInitParam=$(xmllint --xpath "boolean(//*[local-name()='filter']/*[local-name()='init-param']/*[local-name()='param-name' and text()='$paramName'])" "$webXml")
+        if [[ $searchInitParam == "true" ]]; then
+          echo "Removing $scope: $paramName"
+          sed -i "/<init-param>/{:a;N;/<\/init-param>/!ba;/<param-name>$paramName<\/param-name>/d}" $webXml
+          #xmlstarlet ed -P -L \
+          #  -N x="https://jakarta.ee/xml/ns/jakartaee" \
+          #  -d "//x:web-app/x:filter/x:init-param[x:param-name='$paramName']" $webXml
+        else
+          echo "'$paramName' not found in $scope. No removal needed."
+        fi
+      fi
+      ;;
+      
+    *)
+      echo "Invalid action: $action"
+      echo "Usage: updateContextParamPropertyInWebXml <update|remove> <paramName> [paramValue] <context-param|init-param>"
+      return 1
+      ;;
+  esac
+}
+
+function applyWebXmlChangesFromFile() {
+  propertyFile="$1"
+  scope=""  # current section: context-param or init-param
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim whitespace
+    line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+    # Skip empty or commented lines
+    [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+    # Section headers [context-param] / [init-param]
+    if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+      case "${BASH_REMATCH[1]}" in
+        context-param|init-param) scope="${BASH_REMATCH[1]}" ;;
+        *) echo "Warning: Unknown section [${BASH_REMATCH[1]}]" ; scope="unknown" ;;
+      esac
+      continue
+    fi
+
+    # Remove case: -paramName
+    if [[ "$line" =~ ^-(.+)$ ]]; then
+      [[ -z "$scope" ]] && scope="context-param"   # default if missing
+      updateContextParamPropertyInWebXml remove "${BASH_REMATCH[1]}" "" "$scope"
+
+    # Add/Remove case: paramName=paramValue
+    elif [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+      [[ -z "$scope" ]] && scope="context-param"   # default if missing
+      if [[ "$scope" == "context-param" || "$scope" == "init-param" ]]; then
+        paramName="${BASH_REMATCH[1]}"
+        paramValue="${BASH_REMATCH[2]}"
+        paramValue="${paramValue//\\#/\\#}"  # allow escaped "#"
+        # Escape special characters & < > " ' in parameter value
+        if [[ -n "$paramValue" ]]; then
+            paramValue=$(echo "$paramValue" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g;')
+        fi
+        updateContextParamPropertyInWebXml update "$paramName" "$paramValue" "$scope"
+      else
+        echo "No action as the scope: $scope should be either context-param or init-param. Check your configuration file."
+      fi
+    else
+      echo "Skipping invalid line: $line"
+    fi
+  done < "$propertyFile"
 }
 
 if [ -f "/config/web-configuration.properties" ]; then
-	echo "Configure context-param properties in web.xml"
-	file="/config/web-configuration.properties"
-	while IFS='=' read -r key value
-	do
-    # Check if non blank or commented line
-    if [ -n "$key" ] && [[ "$key" != "#"* ]]; then
-      updateContextParamPropertyInWebXml "$key" "$value"
-    fi
-  done < <(grep . "$file")
+	echo "Configure context-param or init-param properties in the web.xml"
+  applyWebXmlChangesFromFile "/config/web-configuration.properties"
 else
-  echo "No web.xml configuration file provided"
+  echo "Web-configuration.properties file not provided. No changes to web.xml file."
 fi
 
 if [ -n "$ENABLE_TLS_AUTH" ] && [ "$ENABLE_TLS_AUTH" = true ]; then


### PR DESCRIPTION
The updated script allows to edit web.xml `<context-param>` and `<init-param>` using a configuration file with the following syntax:
```
# regression support on context-param
# add or update the <param-name> element and its value of a <context-param>
paramName=paramValue

# remove <context-param> entirely if found matching <param-name>  
-paramName

# new implementation to distinguish between context-param and init-param configuration
[context-param]
# add or update the <param-name> element and its value of a <context-param>
paramName=paramValue

# remove <context-param> entirely if found matching <param-name>  
-paramName

[init-param]
# add or update the <param-name> element and its value of a <init-param>
paramName=paramValue

# remove <init-param> entirely if found matching <param-name>  
-paramName
```

I did not use xmlstarlet in the end as I found a sed command that can remove the `<context-param>` or `<init-param>`. However, if we want a xmlstarlet(requiring installation of xmlstarlet), here's the command:
```
# to remove <context-param> based on <param-name>
xmlstarlet ed -P -L \
  -N x="https://jakarta.ee/xml/ns/jakartaee" \
  -d "//x:web-app/x:context-param[x:param-name='$paramName']" $webXml

# to remove <init-param> that is under <filter> node based on <param-name>
xmlstarlet ed -P -L \
  -N x="https://jakarta.ee/xml/ns/jakartaee" \
  -d "//x:web-app/x:filter/x:init-param[x:param-name='$paramName']" $webXml
```